### PR TITLE
manually parse date to support the Hermes engine

### DIFF
--- a/lib/date/dateParser.ts
+++ b/lib/date/dateParser.ts
@@ -1,0 +1,25 @@
+import {compileSpec} from './isFormat';
+
+export function parse (d: Date, zone: string): Date {
+    const {rgx} = compileSpec('DD/MM/YYYY, HH:mm:ss');
+    const localeString = d.toLocaleString('nl-BE', {
+        timeZone: zone,
+        day: '2-digit',
+        month: '2-digit',
+        year:'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    });
+
+    const matches = rgx.exec(localeString);
+    if (!matches) throw new Error('dateParser/parse: failed to parse date');
+    // Build the new date based on the matched values
+    return new Date(Number(matches[3]),
+        Number(matches[2]) - 1,
+        Number(matches[1]),
+        Number(matches[4]),
+        Number(matches[5]),
+        Number(matches[6])
+    );
+}

--- a/lib/date/format.ts
+++ b/lib/date/format.ts
@@ -2,6 +2,7 @@
 
 import {convertToDate} from './convertToDate';
 import LRU from '../caching/LRU';
+import {parse} from './dateParser';
 
 const WEEK_STARTS = {
     mon: 'mon',
@@ -126,7 +127,7 @@ function toZone (d:Date, zone:string):Date {
     /* Get the target timezone offset in minutes */
     let zone_time:number|null = null;
     try {
-        zone_time = new Date(d.toLocaleString(DEFAULT_LOCALE, {timeZone: zone})).getTime() + d.getMilliseconds();
+        zone_time = parse(d, zone).getTime() + d.getMilliseconds();
     } catch {
         throw new Error(`format: Invalid zone passed - ${zone}`);
     }

--- a/lib/date/isFormat.ts
+++ b/lib/date/isFormat.ts
@@ -59,7 +59,7 @@ const spec_pat_cache = new LRU<string, {rgx:RegExp;tokens:number[]}>({max_size: 
  * @param {string} spec - Spec to compile
  * @param {boolean} is_chunk - Whether or not this is a subchunk
  */
-function compileSpec (spec:string, is_chunk:boolean = false) {
+export function compileSpec (spec:string, is_chunk:boolean = false) {
     let cached = spec_pat_cache.get(spec);
     if (cached !== undefined) return cached;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@valkyriestudios/utils",
-    "version": "12.29.0",
+    "version": "12.29.1",
     "description": "A collection of single-function utilities for common tasks",
     "author": {
         "name": "Peter Vermeulen",


### PR DESCRIPTION
Minor fix that adds support for the Hermes engine which React Native uses. 

**Changes**
- Timezone conversions will use a manual date parser based on is `isFormat` parser.